### PR TITLE
fix a bug occuring with non existant table during migration in RAILS_ENV=test with postgres

### DIFF
--- a/lib/validates_lengths_from_database.rb
+++ b/lib/validates_lengths_from_database.rb
@@ -9,6 +9,7 @@ module ValidatesLengthsFromDatabase
 
   module ClassMethods
     def validates_lengths_from_database(options = {})
+      return unless self.table_exists? #return if table does not exist. Happens in test env during migration
       options.symbolize_keys!
 
       raise ArgumentError, "The :only option to validates_lengths_from_database must be an array." if options[:only] and !options[:only].is_a?(Array)


### PR DESCRIPTION
It looks like in RAILS_ENV=test models are loaded during rake db:migrate which causes an error:
PGError: ERROR:  relation "tablename" does not exist
that breaks a migration

Cheers,
Tadas Tamosauskas
