### PR TITLE
Options for lazy people

### DIFF
--- a/lib/validates_lengths_from_database.rb
+++ b/lib/validates_lengths_from_database.rb
@@ -12,9 +12,8 @@ module ValidatesLengthsFromDatabase
       options.symbolize_keys!
 
       return false unless self.table_exists?
-
-      raise ArgumentError, "The :only option to validates_lengths_from_database must be an array." if options[:only] and !options[:only].is_a?(Array)
-      raise ArgumentError, "The :except option to validates_lengths_from_database must be an array." if options[:except] and !options[:except].is_a?(Array)
+      options[:only]    = Array[options[:only]]   if options[:only] && !options[:only].is_a?(Array)
+      options[:except]  = Array[options[:except]] if options[:except] && !options[:except].is_a?(Array)
 
       if options[:only]
         columns_to_validate = options[:only].map(&:to_s)


### PR DESCRIPTION
I'm lazy so, I wanted to make less code
That's not an important improvement, but you can do

```
validates_lengths_from_database except: :avatar
```

instead of 

```
validates_lengths_from_database except: [:avatar]
```
