### PR TITLE
Use before_validation callback to "lazily" validate column lengths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 Manifest
 pkg
 .bundle
+.project

--- a/lib/validates_lengths_from_database.rb
+++ b/lib/validates_lengths_from_database.rb
@@ -38,6 +38,8 @@ module ValidatesLengthsFromDatabase
           
           ActiveModel::Validations::LengthValidator.new(:maximum => column_limit, :allow_blank => true, :attributes => [column]).validate(self)
         end
+        
+        true
       end
 
       nil

--- a/lib/validates_lengths_from_database/all_columns_length_validator.rb
+++ b/lib/validates_lengths_from_database/all_columns_length_validator.rb
@@ -1,0 +1,39 @@
+module ValidatesLengthsFromDatabase
+  class AllColumnsLengthValidator < ActiveModel::EachValidator
+    
+    def initialize(model, options)
+      @model = model
+      super options.merge(:attributes => [:bogus])
+    end
+    
+    def attributes
+      columns.keys
+    end
+    
+    def validate_each(record, attribute, value)
+      validator = ActiveModel::Validations::LengthValidator.new(:attributes => [attribute], :maximum => columns[attribute])
+      validator.validate_each(record, attribute, value)
+    end
+    
+    def columns
+      if options[:only]
+        columns_to_validate = options[:only].map(&:to_s)
+      else
+        columns_to_validate = @model.column_names.map(&:to_s)
+        columns_to_validate -= options[:except].map(&:to_s) if options[:except]
+      end
+      
+      columns_to_validate.inject({}) do |all, column|
+        column_schema = @model.columns.find {|c| c.name == column }
+        if !column_schema.nil? && [:string, :text].include?(column_schema.type)
+          if column_limit = options[:limit][column_schema.type] || column_schema.limit
+            all.merge!(column.to_sym => column_limit)
+          end
+        end
+        
+        all
+      end
+    end
+    
+  end
+end


### PR DESCRIPTION
My initial commit https://github.com/joelvh/validates_lengths_from_database/commit/00ac9c3bf7d0a644bf5279e97355126d5f66a6be included a validator that gets added to the model. It works, but using the `before_validation` callback in my latest commit keeps the original code more intact.