### PR TITLE
Update appraisal gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,10 @@ GEM
     activesupport (3.2.3)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    appraisal (0.4.1)
+    appraisal (1.0.2)
       bundler
       rake
+      thor (>= 0.14.0)
     arel (3.0.2)
     builder (3.0.0)
     diff-lcs (1.1.2)
@@ -39,13 +40,14 @@ GEM
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.5.0)
     sqlite3 (1.3.5)
+    thor (0.19.1)
     tzinfo (0.3.32)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  appraisal (~> 0.4.0)
+  appraisal (~> 1.0.2)
   i18n
   rake
   rdoc (~> 3.12)

--- a/gemfiles/4.0.gemfile.lock
+++ b/gemfiles/4.0.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /Users/bhughes/Workspace/validates_lengths_from_database
+  remote: ../
   specs:
     validates_lengths_from_database (0.2.0)
       activerecord (>= 2.3.2)
@@ -31,9 +31,10 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.33)
-    appraisal (0.4.1)
+    appraisal (1.0.2)
       bundler
       rake
+      thor (>= 0.14.0)
     arel (4.0.0.beta1)
     atomic (1.0.1)
     builder (3.1.4)
@@ -101,7 +102,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  appraisal (~> 0.4.0)
+  appraisal (~> 1.0.2)
   i18n
   rails (~> 4.0.0.beta1)
   rake

--- a/validates_lengths_from_database.gemspec
+++ b/validates_lengths_from_database.gemspec
@@ -10,20 +10,20 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/rubiety/validates_lengths_from_database"
   s.summary     = "Automatic maximum-length validations."
   s.description = "Introspects your database string field maximum lengths and automatically defines length validations."
-  
+
   s.files        = Dir["{lib,spec,rails}/**/*", "[A-Z]*", "init.rb"]
   s.require_path = "lib"
-  
+
   s.rubyforge_project = s.name
   s.required_rubygems_version = ">= 1.3.4"
-  
+
   s.add_dependency("activerecord", [">= 2.3.2"])
   s.add_development_dependency("rspec", ["~> 2.0"])
   s.add_development_dependency("sqlite3", ["~> 1.3.4"])
-  s.add_development_dependency('appraisal', ["~> 0.4.0"])
+  s.add_development_dependency("appraisal", ["~> 1.0.2"])
   s.add_development_dependency("rdoc", ["~> 3.12"])
   s.add_development_dependency "rake"
-  
+
   # I'm not sure why this isn't installed along with activesupport,
   # but for whatever reason running `bundle install` doesn't install
   # i18n so I'm adding it here for now.


### PR DESCRIPTION
Updates the appraisal gem to the latest released version.

I had to do this in order to run the specs on Rails 4.0.
