### PR TITLE
Make spec runnable on postgresql

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     i18n (0.6.0)
     json (1.6.6)
     multi_json (1.2.0)
+    pg (0.17.1)
     rake (0.9.2.2)
     rdoc (3.12)
       json (~> 1.4)
@@ -49,6 +50,7 @@ PLATFORMS
 DEPENDENCIES
   appraisal (~> 1.0.2)
   i18n
+  pg (~> 0.17.1)
   rake
   rdoc (~> 3.12)
   rspec (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,10 @@ GEM
     activesupport (3.2.3)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    appraisal (0.4.1)
+    appraisal (1.0.2)
       bundler
       rake
+      thor (>= 0.14.0)
     arel (3.0.2)
     builder (3.0.0)
     diff-lcs (1.1.2)
@@ -39,13 +40,14 @@ GEM
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.5.0)
     sqlite3 (1.3.5)
+    thor (0.19.1)
     tzinfo (0.3.32)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  appraisal (~> 0.4.0)
+  appraisal (~> 1.0.2)
   i18n
   rake
   rdoc (~> 3.12)

--- a/gemfiles/4.0.gemfile.lock
+++ b/gemfiles/4.0.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /Users/bhughes/Workspace/validates_lengths_from_database
+  remote: ../
   specs:
     validates_lengths_from_database (0.2.0)
       activerecord (>= 2.3.2)
@@ -31,9 +31,10 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.33)
-    appraisal (0.4.1)
+    appraisal (1.0.2)
       bundler
       rake
+      thor (>= 0.14.0)
     arel (4.0.0.beta1)
     atomic (1.0.1)
     builder (3.1.4)
@@ -101,7 +102,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  appraisal (~> 0.4.0)
+  appraisal (~> 1.0.2)
   i18n
   rails (~> 4.0.0.beta1)
   rake

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -1,13 +1,17 @@
 ActiveRecord::Schema.define(:version => 0) do
-  
   create_table :articles, :force => true do |t|
     t.string :string_1, :limit => 5
     t.string :string_2, :limit => 5
-    t.text :text_1, :limit => 5
+    if postgresql?
+      # PostgreSQL doesn't support limits on text columns
+      t.text :text_1
+    else
+      t.text :text_1, :limit => 5
+    end
     t.date :date_1
     t.integer :integer_1
   end
-  
+
   create_table :articles_high_limit, :force => true do |t|
     t.string :string_1
     t.string :string_2
@@ -15,5 +19,5 @@ ActiveRecord::Schema.define(:version => 0) do
     t.date :date_1
     t.integer :integer_1
   end
-  
 end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,10 @@ config = YAML::load(IO.read(File.join(File.dirname(__FILE__), 'db', 'database.ym
 ActiveRecord::Base.configurations = {'test' => config[ENV['DB'] || 'sqlite3']}
 ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations['test'])
 
+def postgresql?
+   ActiveRecord::Base.connection.instance_values["config"][:adapter] == 'postgresql'
+ end
+
 # Load Test Schema into the Database
 load(File.dirname(__FILE__) + "/db/schema.rb")
 

--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -51,7 +51,7 @@ describe ValidatesLengthsFromDatabase do
       it "should have errors on all string/text attributes" do
         @article.errors["string_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
-        @article.errors["text_1"].join.should =~ /too long/
+        @article.errors["text_1"].join.should =~ /too long/  unless postgresql?  # PostgreSQL doesn't support limits on text columns
       end
     end
 
@@ -63,7 +63,7 @@ describe ValidatesLengthsFromDatabase do
       end
     end
   end
-  
+
   context "Model with validates_lengths_from_database :limit => 10" do
     before do
       class ArticleValidateLimit < ActiveRecord::Base
@@ -94,7 +94,7 @@ describe ValidatesLengthsFromDatabase do
       end
     end
   end
-  
+
   context "Model with validates_lengths_from_database :limit => {:string => 5, :text => 100}" do
     before do
       class ArticleValidateSpecificLimit < ActiveRecord::Base
@@ -117,7 +117,7 @@ describe ValidatesLengthsFromDatabase do
       end
     end
   end
-  
+
   context "Model with validates_lengths_from_database :only => [:string_1, :text_1]" do
     before do
       class ArticleValidateOnly < ActiveRecord::Base
@@ -136,7 +136,7 @@ describe ValidatesLengthsFromDatabase do
       it "should have errors on only string_1 and text_1" do
         @article.errors["string_1"].join.should =~ /too long/
         (@article.errors["string_2"] || []).should be_empty
-        @article.errors["text_1"].join.should =~ /too long/
+        @article.errors["text_1"].join.should =~ /too long/ unless postgresql?  # PostgreSQL doesn't support limits on text columns
       end
     end
 
@@ -179,5 +179,4 @@ describe ValidatesLengthsFromDatabase do
       end
     end
   end
-  
 end

--- a/validates_lengths_from_database.gemspec
+++ b/validates_lengths_from_database.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec", ["~> 2.0"])
   s.add_development_dependency("sqlite3", ["~> 1.3.4"])
   s.add_development_dependency("appraisal", ["~> 1.0.2"])
+  s.add_development_dependency("pg", ["~> 0.17.1"])
+  s.add_development_dependency("appraisal", ["~> 0.4.0"])
   s.add_development_dependency("rdoc", ["~> 3.12"])
   s.add_development_dependency "rake"
 

--- a/validates_lengths_from_database.gemspec
+++ b/validates_lengths_from_database.gemspec
@@ -10,20 +10,20 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/rubiety/validates_lengths_from_database"
   s.summary     = "Automatic maximum-length validations."
   s.description = "Introspects your database string field maximum lengths and automatically defines length validations."
-  
+
   s.files        = Dir["{lib,spec,rails}/**/*", "[A-Z]*", "init.rb"]
   s.require_path = "lib"
-  
+
   s.rubyforge_project = s.name
   s.required_rubygems_version = ">= 1.3.4"
-  
+
   s.add_dependency("activerecord", [">= 2.3.2"])
   s.add_development_dependency("rspec", ["~> 2.0"])
   s.add_development_dependency("sqlite3", ["~> 1.3.4"])
-  s.add_development_dependency('appraisal', ["~> 0.4.0"])
+  s.add_development_dependency("appraisal", ["~> 1.0.2"])
   s.add_development_dependency("rdoc", ["~> 3.12"])
   s.add_development_dependency "rake"
-  
+
   # I'm not sure why this isn't installed along with activesupport,
   # but for whatever reason running `bundle install` doesn't install
   # i18n so I'm adding it here for now.


### PR DESCRIPTION
Hello Ben,

these are the changes I had to make to run the specs run on postgresql:
  - Update the appraisal gem
  - Add the "pg" gem to the development dependencies
  - Don't apply a :limit on "text" columns, as postgresql doesn't support this

