### PR TITLE
validate more column types

### DIFF
--- a/lib/validates_lengths_from_database.rb
+++ b/lib/validates_lengths_from_database.rb
@@ -16,7 +16,7 @@ module ValidatesLengthsFromDatabase
       options[:limit] ||= {}
 
       if options[:limit] and !options[:limit].is_a?(Hash)
-        options[:limit] = {:string => options[:limit], :text => options[:limit], :decimal => options[:limit], :integer => options[:limit]}
+        options[:limit] = {:string => options[:limit], :text => options[:limit], :decimal => options[:limit], :integer => options[:limit], :float => options[:limit]}
       end
       @@validate_lengths_from_database_options = options
 
@@ -46,7 +46,7 @@ module ValidatesLengthsFromDatabase
         next if column_schema.nil?
         next if column_schema.respond_to?(:array) && column_schema.array
 
-        if [:string, :text, :integer, :decimal].include?(column_schema.type)      
+        if [:string, :text, :integer, :decimal, :float].include?(column_schema.type)      
           column_limit = options[:limit][column_schema.type] || column_schema.limit          
 
           ActiveModel::Validations::LengthValidator.new(:maximum => column_limit, :allow_blank => true, :attributes => [column]).validate(self) if column_limit

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -14,6 +14,7 @@ ActiveRecord::Schema.define(:version => 0) do
   
     t.integer :integer_1, :limit => 5
     t.decimal :decimal_1, :precision => 5, :scale => 2
+    t.float :float_1, :limit => 5
 
     if database_supports_arrays?
       t.string :array_1, :array => true, :limit => 5
@@ -27,6 +28,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.date :date_1
     t.integer :integer_1
     t.decimal :decimal_1, :precision => 11, :scale => 2
+    t.float :float_1
 
     if database_supports_arrays?
       t.string :array_1, :array => true

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -11,7 +11,9 @@ ActiveRecord::Schema.define(:version => 0) do
     end
 
     t.date :date_1
-    t.integer :integer_1
+  
+    t.integer :integer_1, :limit => 5
+    t.decimal :decimal_1, :precision => 5, :scale => 2
 
     if database_supports_arrays?
       t.string :array_1, :array => true, :limit => 5
@@ -24,6 +26,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.text :text_1
     t.date :date_1
     t.integer :integer_1
+    t.decimal :decimal_1, :precision => 11, :scale => 2
 
     if database_supports_arrays?
       t.string :array_1, :array => true

--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -7,7 +7,8 @@ describe ValidatesLengthsFromDatabase do
     :string_2 => "123456789",
     :text_1 => "123456789",
     :date_1 => Date.today,
-    :integer_1 => 123
+    :integer_1 => 123456789,
+    :decimal_1 => 123456789.01
   }
 
   SHORT_ATTRIBUTES = {
@@ -15,7 +16,8 @@ describe ValidatesLengthsFromDatabase do
     :string_2 => "12",
     :text_1 => "12",
     :date_1 => Date.today,
-    :integer_1 => 123
+    :integer_1 => 123,
+    :decimal_1 => 12.34
   }
 
   before(:all) do
@@ -115,6 +117,9 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
         @article.errors["text_1"].join.should =~ /too long/  unless postgresql?  # PostgreSQL doesn't support limits on text columns
+        @article.errors["decimal_1"].join.should =~ /too long/
+        @article.errors["decimal_1"].join.should =~ /less than/
+        @article.errors["integer_1"].join.should =~ /too long/  
       end
     end
 
@@ -156,11 +161,14 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
         @article.errors["text_1"].join.should =~ /too long/
+        @article.errors["text_1"].join.should =~ /too long/
+        @article.errors["integer_1"].join.should =~ /too long/
       end
     end
 
     context "an article with short attributes" do
       before { @article = ArticleValidateLimit.new(SHORT_ATTRIBUTES); @article.valid? }
+
 
       it "should be valid" do
         @article.should be_valid
@@ -168,11 +176,11 @@ describe ValidatesLengthsFromDatabase do
     end
   end
 
-  context "Model with validates_lengths_from_database :limit => {:string => 5, :text => 100}" do
+  context "Model with validates_lengths_from_database :limit => {:string => 5, :text => 100, :integer => 100, :decimal => 100}" do
     before do
       class ArticleValidateSpecificLimit < ActiveRecord::Base
         self.table_name = "articles_high_limit"
-        validates_lengths_from_database :limit => {:string => 5, :text => 100}
+        validates_lengths_from_database :limit => {:string => 5, :text => 100, :integer => 100, :decimal => 100}
       end
     end
 
@@ -187,6 +195,8 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
         @article.errors["text_1"].should_not be_present
+        @article.errors["decimal_1"].should_not be_present
+        @article.errors["integer_1"].should_not be_present
       end
     end
   end
@@ -210,6 +220,8 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_1"].join.should =~ /too long/
         (@article.errors["string_2"] || []).should be_empty
         @article.errors["text_1"].join.should =~ /too long/ unless postgresql?  # PostgreSQL doesn't support limits on text columns
+        (@article.errors["decimal_1"] || []).should be_empty
+        (@article.errors["integer_1"] || []).should be_empty
       end
     end
 
@@ -240,6 +252,9 @@ describe ValidatesLengthsFromDatabase do
       it "should have errors on columns other than string_1 and text_1 only" do
         (@article.errors["string_1"] || []).should be_empty
         (@article.errors["text_1"] || []).should be_empty
+        @article.errors["decimal_1"].join.should =~ /too long/
+        @article.errors["decimal_1"].join.should =~ /less than/
+        @article.errors["integer_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
       end
     end

--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -119,7 +119,7 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
         @article.errors["text_1"].join.should =~ /too long/  unless postgresql?  # PostgreSQL doesn't support limits on text columns
-        @article.errors["decimal_1"].join.should =~ /too long/ unless postgresql?
+        @article.errors["decimal_1"].join.should =~ /too long/ 
         @article.errors["decimal_1"].join.should =~ /less than/
         @article.errors["integer_1"].join.should =~ /too long/  
         @article.errors["float_1"].join.should =~ /too long/
@@ -164,8 +164,7 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
         @article.errors["text_1"].join.should =~ /too long/
-        @article.errors["decimal_1"].join.should =~ /too long/ unless postgresql?
-        @article.errors["decimal_1"].join.should =~ /less than/
+        @article.errors["decimal_1"].join.should =~ /too long/ 
         @article.errors["integer_1"].join.should =~ /too long/
         @article.errors["float_1"].join.should =~ /too long/
       end
@@ -259,7 +258,7 @@ describe ValidatesLengthsFromDatabase do
       it "should have errors on columns other than string_1 and text_1 only" do
         (@article.errors["string_1"] || []).should be_empty
         (@article.errors["text_1"] || []).should be_empty
-        @article.errors["decimal_1"].join.should =~ /too long/ unless postgresql?
+        @article.errors["decimal_1"].join.should =~ /too long/ 
         @article.errors["decimal_1"].join.should =~ /less than/
         @article.errors["integer_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/

--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -8,7 +8,8 @@ describe ValidatesLengthsFromDatabase do
     :text_1 => "123456789",
     :date_1 => Date.today,
     :integer_1 => 123456789,
-    :decimal_1 => 123456789.01
+    :decimal_1 => 123456789.01,
+    :float_1 => 123456789.01
   }
 
   SHORT_ATTRIBUTES = {
@@ -17,7 +18,8 @@ describe ValidatesLengthsFromDatabase do
     :text_1 => "12",
     :date_1 => Date.today,
     :integer_1 => 123,
-    :decimal_1 => 12.34
+    :decimal_1 => 12.34,
+    :float_1 => 12.34
   }
 
   before(:all) do
@@ -120,6 +122,7 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["decimal_1"].join.should =~ /too long/
         @article.errors["decimal_1"].join.should =~ /less than/
         @article.errors["integer_1"].join.should =~ /too long/  
+        @article.errors["float_1"].join.should =~ /too long/
       end
     end
 
@@ -163,6 +166,7 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["text_1"].join.should =~ /too long/
         @article.errors["text_1"].join.should =~ /too long/
         @article.errors["integer_1"].join.should =~ /too long/
+        @article.errors["float_1"].join.should =~ /too long/
       end
     end
 
@@ -176,11 +180,11 @@ describe ValidatesLengthsFromDatabase do
     end
   end
 
-  context "Model with validates_lengths_from_database :limit => {:string => 5, :text => 100, :integer => 100, :decimal => 100}" do
+  context "Model with validates_lengths_from_database :limit => {:string => 5, :text => 100, :integer => 100, :decimal => 100, :float => 100}" do
     before do
       class ArticleValidateSpecificLimit < ActiveRecord::Base
         self.table_name = "articles_high_limit"
-        validates_lengths_from_database :limit => {:string => 5, :text => 100, :integer => 100, :decimal => 100}
+        validates_lengths_from_database :limit => {:string => 5, :text => 100, :integer => 100, :decimal => 100, :float => 100}
       end
     end
 
@@ -197,6 +201,7 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["text_1"].should_not be_present
         @article.errors["decimal_1"].should_not be_present
         @article.errors["integer_1"].should_not be_present
+        @article.errors["float_1"].should_not be_present
       end
     end
   end
@@ -222,6 +227,7 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["text_1"].join.should =~ /too long/ unless postgresql?  # PostgreSQL doesn't support limits on text columns
         (@article.errors["decimal_1"] || []).should be_empty
         (@article.errors["integer_1"] || []).should be_empty
+        (@article.errors["float_1"] || []).should be_empty
       end
     end
 
@@ -256,6 +262,7 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["decimal_1"].join.should =~ /less than/
         @article.errors["integer_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
+        @article.errors["float_1"].join.should =~ /too long/
       end
     end
 

--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -119,7 +119,7 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
         @article.errors["text_1"].join.should =~ /too long/  unless postgresql?  # PostgreSQL doesn't support limits on text columns
-        @article.errors["decimal_1"].join.should =~ /too long/
+        @article.errors["decimal_1"].join.should =~ /too long/ unless postgresql?
         @article.errors["decimal_1"].join.should =~ /less than/
         @article.errors["integer_1"].join.should =~ /too long/  
         @article.errors["float_1"].join.should =~ /too long/
@@ -164,7 +164,8 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
         @article.errors["text_1"].join.should =~ /too long/
-        @article.errors["text_1"].join.should =~ /too long/
+        @article.errors["decimal_1"].join.should =~ /too long/ unless postgresql?
+        @article.errors["decimal_1"].join.should =~ /less than/
         @article.errors["integer_1"].join.should =~ /too long/
         @article.errors["float_1"].join.should =~ /too long/
       end
@@ -258,7 +259,7 @@ describe ValidatesLengthsFromDatabase do
       it "should have errors on columns other than string_1 and text_1 only" do
         (@article.errors["string_1"] || []).should be_empty
         (@article.errors["text_1"] || []).should be_empty
-        @article.errors["decimal_1"].join.should =~ /too long/
+        @article.errors["decimal_1"].join.should =~ /too long/ unless postgresql?
         @article.errors["decimal_1"].join.should =~ /less than/
         @article.errors["integer_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/

--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -119,7 +119,6 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
         @article.errors["text_1"].join.should =~ /too long/  unless postgresql?  # PostgreSQL doesn't support limits on text columns
-        @article.errors["decimal_1"].join.should =~ /too long/ 
         @article.errors["decimal_1"].join.should =~ /less than/
         @article.errors["integer_1"].join.should =~ /too long/  
         @article.errors["float_1"].join.should =~ /too long/
@@ -258,7 +257,6 @@ describe ValidatesLengthsFromDatabase do
       it "should have errors on columns other than string_1 and text_1 only" do
         (@article.errors["string_1"] || []).should be_empty
         (@article.errors["text_1"] || []).should be_empty
-        @article.errors["decimal_1"].join.should =~ /too long/ 
         @article.errors["decimal_1"].join.should =~ /less than/
         @article.errors["integer_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/


### PR DESCRIPTION
Integers, decimals, and floats can now be validated by :limit in options or the schema, and I added a less_than validation based on the precision and scale of the decimal. 