### PR TITLE
Fix sharing options between models

### DIFF
--- a/lib/validates_lengths_from_database.rb
+++ b/lib/validates_lengths_from_database.rb
@@ -18,7 +18,7 @@ module ValidatesLengthsFromDatabase
       if options[:limit] and !options[:limit].is_a?(Hash)
         options[:limit] = {:string => options[:limit], :text => options[:limit], :decimal => options[:limit], :integer => options[:limit], :float => options[:limit]}
       end
-      @@validate_lengths_from_database_options = options
+      @validate_lengths_from_database_options = options
 
       validate :validate_lengths_from_database
 
@@ -26,7 +26,7 @@ module ValidatesLengthsFromDatabase
     end
 
     def validate_lengths_from_database_options
-      @@validate_lengths_from_database_options
+      @validate_lengths_from_database_options
     end
   end
 

--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -106,6 +106,11 @@ describe ValidatesLengthsFromDatabase do
         self.table_name = "articles"
         validates_lengths_from_database
       end
+
+      class ArticleValidateText < ActiveRecord::Base
+        self.table_name = "articles"
+        validates_lengths_from_database :only => [:text_1]
+      end
     end
 
     context "an article with overloaded attributes" do


### PR DESCRIPTION
@@class_variables are one of the worst ideas ever in Ruby and
they should burn in hell. Please don't use it ever again in any
software, unless you intend to make others' life miserable :)

Explanation: compare

```ruby
module A
  def hello
    @@hello
  end

  def set_hello
    @@hello = self.name
  end
end

class B
  extend A
end

class C
  extend A
end

B.set_hello
C.set_hello
puts B.hello
puts C.hello
```

with

```ruby
module A1
  def hello
    @hello
  end

  def set_hello
    @hello = self.name
  end
end

class B1
  extend A1
end

class C1
  extend A1
end

B1.set_hello
C1.set_hello
puts B1.hello
puts C1.hello
```