### PR TITLE
Handle STI properly

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -50,7 +50,27 @@ Or to set the limit differently for string (VARCHAR) and (TEXT) columns:
     validates_lengths_from_database :limit => {:string => 255, :text => 4092}
   end
 
-Note that unfortunately this cannot be done at a global level directly against ActiveRecord::Base, since the +validates_length_from_database+ method requires the class to have a table name (with the ability to load the schema).
+Since v0.5.2, it's possible to use the `validate_lengths_from_database`
+on an abstract parent (without a table), such as +ApplicationRecord+ or <tt>ActiveRecord::Base</tt>.
+
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+    validates_lengths_from_database :limit => 255
+  end
+
+  # This will use the validations with default options (from parent)
+  class Post < ApplicationRecord
+  end
+
+  # This will use the validations, with overriding the default options (the limit will not be applied)
+  class User < ApplicationRecord
+    validates_lengths_from_database :only => [:name]
+  end
+
+  # This will use the validations, using the default options + adding some class specific customizations
+  class Comment < ApplicationRecord
+    validate_lengths_from_database_options[:only] << :name
+  end
 
 == Running Tests
 

--- a/lib/validates_lengths_from_database.rb
+++ b/lib/validates_lengths_from_database.rb
@@ -26,7 +26,16 @@ module ValidatesLengthsFromDatabase
     end
 
     def validate_lengths_from_database_options
-      @validate_lengths_from_database_options
+      if defined? @validate_lengths_from_database_options
+        @validate_lengths_from_database_options
+      else
+        # in case we inherited the validations, copy the options so that we can update it in child
+        # without affecting the parent
+        @validate_lengths_from_database_options = superclass.validate_lengths_from_database_options.inject({}) do |hash, (key, value)|
+          value = value.dup if value.respond_to?(:dup)
+          hash.update(key => value)
+        end
+      end
     end
   end
 

--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -26,6 +26,11 @@ describe ValidatesLengthsFromDatabase do
     ActiveSupport::Deprecation.silenced = true
   end
 
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+    validates_lengths_from_database :limit => 255
+  end
+
   context "Model without associated table" do
     specify "defining validates_lengths_from_database should not raise an error" do
       lambda {
@@ -130,12 +135,18 @@ describe ValidatesLengthsFromDatabase do
       end
     end
 
-    context "STI" do
+    context "inheritance" do
       before do
-        class ArticleValidateChild < ArticleValidateText
+        class ArticleValidateChild < ApplicationRecord
+          self.table_name = "articles"
+          validates_lengths_from_database :only => [:string_1]
         end
-        class ArticleValidateChildOverwrite < ArticleValidateText
+        class ArticleValidateChildOverwrite < ArticleValidateChild
           validate_lengths_from_database_options[:only] << :string_2
+        end
+        class ArticleWithoutValidations < ApplicationRecord
+          self.table_name = "articles"
+          validates_lengths_from_database :only => []
         end
       end
 

--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -109,7 +109,7 @@ describe ValidatesLengthsFromDatabase do
 
       class ArticleValidateText < ActiveRecord::Base
         self.table_name = "articles"
-        validates_lengths_from_database :only => [:text_1]
+        validates_lengths_from_database :only => [:string_1]
       end
     end
 
@@ -127,6 +127,30 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["decimal_1"].join.should =~ /less than/
         @article.errors["integer_1"].join.should =~ /too long/  
         @article.errors["float_1"].join.should =~ /too long/
+      end
+    end
+
+    context "STI" do
+      before do
+        class ArticleValidateChild < ArticleValidateText
+        end
+        class ArticleValidateChildOverwrite < ArticleValidateText
+          validate_lengths_from_database_options[:only] << :string_2
+        end
+      end
+
+      it "should inherit the validation options from the parent" do
+        @article = ArticleValidateChild.new(LONG_ATTRIBUTES)
+        @article.valid?
+        @article.errors["string_1"].join.should =~ /too long/
+        @article.errors["string_2"].join.should_not =~ /too long/
+      end
+
+      it "should allow changing the validation options of child" do
+        @article = ArticleValidateChildOverwrite.new(LONG_ATTRIBUTES)
+        @article.valid?
+        @article.errors["string_1"].join.should =~ /too long/
+        @article.errors["string_2"].join.should =~ /too long/
       end
     end
 


### PR DESCRIPTION
538b1a15f3 made the isolation better but it came at cost of STI working
worse that before. This commit ensures to copy the original options from
superclass if not present.

I also document about possibility to set the validations globally, as the
limitation should be fixed now, including way to customize them in children.