### PR TITLE
Don't validate length on numbers

### DIFF
--- a/lib/validates_lengths_from_database.rb
+++ b/lib/validates_lengths_from_database.rb
@@ -54,20 +54,19 @@ module ValidatesLengthsFromDatabase
         column_schema = self.class.columns.find {|c| c.name == column }
         next if column_schema.nil?
         next if column_schema.respond_to?(:array) && column_schema.array
-
-        if [:string, :text, :integer, :decimal, :float].include?(column_schema.type)      
-          column_limit = options[:limit][column_schema.type] || column_schema.limit          
-
-          ActiveModel::Validations::LengthValidator.new(:maximum => column_limit, :allow_blank => true, :attributes => [column]).validate(self) if column_limit
-
-          if column_schema.type == :decimal && column_schema.precision && column_schema.scale
-
+        next unless [:string, :text, :decimal].include?(column_schema.type)
+        case column_schema.type
+        when :string, :text
+          column_limit = options[:limit][column_schema.type] || column_schema.limit
+          if column_limit
+            ActiveModel::Validations::LengthValidator.new(:maximum => column_limit, :allow_blank => true, :attributes => [column]).validate(self)
+          end
+        when :decimal
+          if column_schema.precision && column_schema.scale
             max_val = (10 ** column_schema.precision)/(10 ** column_schema.scale)
-
             ActiveModel::Validations::NumericalityValidator.new(:less_than => max_val, :allow_blank => true, :attributes => [column]).validate(self)
           end
         end
-
       end
     end
   end

--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -130,8 +130,6 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_2"].join.should =~ /too long/
         @article.errors["text_1"].join.should =~ /too long/  unless postgresql?  # PostgreSQL doesn't support limits on text columns
         @article.errors["decimal_1"].join.should =~ /less than/
-        @article.errors["integer_1"].join.should =~ /too long/  
-        @article.errors["float_1"].join.should =~ /too long/
       end
     end
 
@@ -203,9 +201,6 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
         @article.errors["text_1"].join.should =~ /too long/
-        @article.errors["decimal_1"].join.should =~ /too long/ 
-        @article.errors["integer_1"].join.should =~ /too long/
-        @article.errors["float_1"].join.should =~ /too long/
       end
     end
 
@@ -219,11 +214,11 @@ describe ValidatesLengthsFromDatabase do
     end
   end
 
-  context "Model with validates_lengths_from_database :limit => {:string => 5, :text => 100, :integer => 100, :decimal => 100, :float => 100}" do
+  context "Model with validates_lengths_from_database :limit => {:string => 5, :text => 100}" do
     before do
       class ArticleValidateSpecificLimit < ActiveRecord::Base
         self.table_name = "articles_high_limit"
-        validates_lengths_from_database :limit => {:string => 5, :text => 100, :integer => 100, :decimal => 100, :float => 100}
+        validates_lengths_from_database :limit => {:string => 5, :text => 100}
       end
     end
 
@@ -239,8 +234,6 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_2"].join.should =~ /too long/
         @article.errors["text_1"].should_not be_present
         @article.errors["decimal_1"].should_not be_present
-        @article.errors["integer_1"].should_not be_present
-        @article.errors["float_1"].should_not be_present
       end
     end
   end
@@ -265,8 +258,6 @@ describe ValidatesLengthsFromDatabase do
         (@article.errors["string_2"] || []).should be_empty
         @article.errors["text_1"].join.should =~ /too long/ unless postgresql?  # PostgreSQL doesn't support limits on text columns
         (@article.errors["decimal_1"] || []).should be_empty
-        (@article.errors["integer_1"] || []).should be_empty
-        (@article.errors["float_1"] || []).should be_empty
       end
     end
 
@@ -298,9 +289,7 @@ describe ValidatesLengthsFromDatabase do
         (@article.errors["string_1"] || []).should be_empty
         (@article.errors["text_1"] || []).should be_empty
         @article.errors["decimal_1"].join.should =~ /less than/
-        @article.errors["integer_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
-        @article.errors["float_1"].join.should =~ /too long/
       end
     end
 


### PR DESCRIPTION
The limit value on column_schema does not specify the length in strings
but on amount of bytes it can take. It also turns out the limit numbers
can be different across different db adapters (they are set on mysql but
not on postgres or sqlite). Also, the length validators don't make sense
for numbers. Numbers above 2**31 (2147483648, which should correspond to
the 4 bytes integer), would pass for length validator of length 10
(such as 3000000000), even when the value would not be valid really.

Since there are no public methods in ActiveRecord to get the minimal and
maximal value, I'm rather removing the validators rather than risking
being incompatible.