### PR TITLE
correctly handle multibyte characters in strings

### DIFF
--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -238,6 +238,23 @@ describe ValidatesLengthsFromDatabase do
     end
   end
 
+  context "Model with validates_lengths_from_database :only => [:text_1], :limit => {:text => 10}" do
+    before do
+      class ArticleValidateOnlyText < ActiveRecord::Base
+        self.table_name = "articles_high_limit"
+        validates_lengths_from_database :only => [:text_1], :limit => {:text => 10}
+      end
+    end
+
+    context "an article with a length equal to max, but a bytesize greater than" do
+      before { @article = ArticleValidateOnlyText.new(:text_1 => "😎"*10); @article.valid? }
+
+      it "should not be valid" do
+        @article.should_not be_valid
+      end
+    end
+  end
+
   context "Model with validates_lengths_from_database :only => [:string_1, :text_1]" do
     before do
       class ArticleValidateOnly < ActiveRecord::Base


### PR DESCRIPTION
This should help resolve #24 

### Problem

In some databases, like MySQL, a `TEXT` column (or its other variants like `MEDIUMTEXT` or `LONGTEXT`), the limit of the column refers to the number of bytes allow, now the number of characters. This is contrary to the "string" column, represented by a `VARCHAR` column type in MySQL, where you specify the number of characters allowed. 

Due to this detail, checking `String#length` against the limit of a column can lead to incorrect validations. This will happen when using a Unicode (or any other multibyte) character set instead of ASCII. 

### Example

```ruby
> "a".length
=> 1

> "a".bytesize
=> 1

> "😎".length 
=> 1

> "😎".bytesize
=> 4
```

### Proposed Solution

To address this problem, I took two possible approaches here depending on the version of ActiveModel. 

In ActiveModel < 5, the LengthValidator accepts a `tokenizer` option that will call any callable object and pass it the value. In this case, I just pass in a lambda that turns the string into an array of bytes. This way, when the subsequent check calls `value.length`, the length will return the number of bytes rather than the number of characters in the string. 

https://github.com/rails/rails/blob/e06a1e09b6bec32b0a05c72a3ae7ceb00f61bf7d/activemodel/lib/active_model/validations/length.rb#L40-L42

Starting in ActiveModel 5 you can no longer pass in a tokenizer. You can instead pass in a Proc for the `maximum` option to the validator, but internally it still just calls `String#length` which will not handle our multibyte character situation properly. 

https://github.com/rails/rails/blob/b9ca94caea2ca6a6cc09abaffaad67b447134079/activemodel/lib/active_model/validations/length.rb#L40-L42

I felt the cleanest solution in this case was just to make our own custom length validator. This custom length validator just tokenizes the string into bytes and then lets the length validator do the rest of the work. 

/cc @rubiety @grosser 