### PR TITLE
handle text vs string as sql uses num chars or bytesize depending on type

### DIFF
--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -222,7 +222,7 @@ describe ValidatesLengthsFromDatabase do
       end
     end
 
-    context "an article with overloaded attributes" do
+    context "an article with string_1 that is too many characters" do
       before { @article = ArticleValidateSpecificLimit.new(LONG_ATTRIBUTES); @article.valid? }
 
       it "should not be valid" do
@@ -233,6 +233,56 @@ describe ValidatesLengthsFromDatabase do
         @article.errors["string_1"].join.should =~ /too long/
         @article.errors["string_2"].join.should =~ /too long/
         @article.errors["text_1"].should_not be_present
+        @article.errors["decimal_1"].should_not be_present
+      end
+    end
+
+    context "an article with string_1 that is too many bytes, but few enough characters" do
+      before do
+        @article = ArticleValidateSpecificLimit.new(
+          LONG_ATTRIBUTES.merge(:string_1 => "😎😎😎😎", :string_2 => "👍👍👍👍")
+        )
+
+        @article.valid?
+      end
+
+      it "should be valid" do
+        @article.should be_valid
+      end
+    end
+
+    context "an article with text_1 that is too many characters" do
+      before do
+        @article = ArticleValidateSpecificLimit.new(LONG_ATTRIBUTES.merge(:text_1 => "a"*101))
+        @article.valid?
+      end
+
+      it "should not be valid" do
+        @article.should_not be_valid
+      end
+
+      it "should have errors on all string/text attributes" do
+        @article.errors["string_1"].join.should =~ /too long/
+        @article.errors["string_2"].join.should =~ /too long/
+        @article.errors["text_1"].join.should =~ /too long/
+        @article.errors["decimal_1"].should_not be_present
+      end
+    end
+
+    context "an article with text_1 that is too many bytes, but few enough characters" do
+      before do
+        @article = ArticleValidateSpecificLimit.new(LONG_ATTRIBUTES.merge(:text_1 => "👍"*99))
+        @article.valid?
+      end
+
+      it "should not be valid" do
+        @article.should_not be_valid
+      end
+
+      it "should have errors on all string/text attributes" do
+        @article.errors["string_1"].join.should =~ /too long/
+        @article.errors["string_2"].join.should =~ /too long/
+        @article.errors["text_1"].join.should =~ /too long/
         @article.errors["decimal_1"].should_not be_present
       end
     end


### PR DESCRIPTION
This is a follow up to #25 to do a little bit of cleanup. 

- Change the name of `UnicodeLengthValidator` to `BytesizeValidator` because that is more accurate to what it does
- extract some larger nested if/else blocks out of the switch-case into private methods
- expand the tests to reflect correct handling of "string" vs. "text" columns

/cc @rubiety @grosser 