### PR TITLE
Speed up column_schema lookup

### DIFF
--- a/lib/validates_lengths_from_database/core.rb
+++ b/lib/validates_lengths_from_database/core.rb
@@ -56,7 +56,7 @@ module ValidatesLengthsFromDatabase
       end
 
       columns_to_validate.each do |column|
-        column_schema = self.class.columns.find {|c| c.name == column }
+        column_schema = self.class.columns_hash[column]
 
         next if column_schema.nil?
         next if column_schema.respond_to?(:array) && column_schema.array


### PR DESCRIPTION
Using `columns_hash` we can get the schema directly using the column name.

Example:

```rb
» Address
=> class Address < ApplicationRecord {
                :id => :integer,
       :street_name => :string,
     :street_number => :string,
         :post_code => :string,
              :city => :string,
    :addressable_id => :integer,
  :addressable_type => :string,
        :created_at => :datetime,
        :updated_at => :datetime
}

» old = Address.columns.find { |column| column.name == 'city' }
=> #<ActiveRecord::ConnectionAdapters::PostgreSQLColumn:0x00007fca242b0700 @name="city", @table_name="addresses", @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x00007fca242b09a8 @sql_type="character varying", @type=:string, @limit=nil, @precision=nil, @scale=nil>, @null=true, @default=nil, @default_function=nil, @collation=nil, @comment=nil, @max_identifier_length=63>

» new = Address.columns_hash['city']
=> #<ActiveRecord::ConnectionAdapters::PostgreSQLColumn:0x00007fca242b0700 @name="city", @table_name="addresses", @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x00007fca242b09a8 @sql_type="character varying", @type=:string, @limit=nil, @precision=nil, @scale=nil>, @null=true, @default=nil, @default_function=nil, @collation=nil, @comment=nil, @max_identifier_length=63>

» old == new
=> true
```