### PR TITLE
Remove redundant init.rb files

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,4 +1,0 @@
-require "validates_lengths_from_database"
-
-ValidatesLengthsFromDatabase::Railtie.insert
-

--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,4 +1,0 @@
-require "validates_lengths_from_database"
-
-ValidatesLengthsFromDatabase::Railtie.insert
-


### PR DESCRIPTION
These files are not actually used and can be removed.

Fixes: 2582868743a76bf36651ba5e96ec78c2c86ca73d