### PR TITLE
Use i18n key for bytesize validation error message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,6 @@
+en:
+  errors:
+    messages:
+      too_long_bytes:
+        one: "is too long (maximum is 1 byte)"
+        other: "is too long (maximum is %{count} bytes)"

--- a/lib/validates_lengths_from_database/core.rb
+++ b/lib/validates_lengths_from_database/core.rb
@@ -103,7 +103,7 @@ module ValidatesLengthsFromDatabase
             :allow_blank => true,
             :attributes => [column],
             :maximum => column_limit,
-            :too_long => "is too long (maximum is %{count} bytes)"
+            :too_long => :too_long_bytes
           )
         end
 

--- a/lib/validates_lengths_from_database/railtie.rb
+++ b/lib/validates_lengths_from_database/railtie.rb
@@ -3,6 +3,11 @@ module ValidatesLengthsFromDatabase
     require "rails"
 
     class Railtie < Rails::Railtie
+      initializer "validates_lengths_from_database.i18n" do
+        locale_path = File.expand_path("../../../config/locales/en.yml", __FILE__)
+        I18n.load_path << locale_path if File.exist?(locale_path)
+      end
+
       initializer "validates_lengths_from_database.extend_active_record" do
         ActiveSupport.on_load(:active_record) do
           ValidatesLengthsFromDatabase::Railtie.insert

--- a/spec/validates_lengths_from_database_spec.rb
+++ b/spec/validates_lengths_from_database_spec.rb
@@ -369,4 +369,49 @@ describe ValidatesLengthsFromDatabase do
     end
   end
 
+  context "i18n support for bytesize validation messages" do
+    before do
+      class ArticleValidateI18n < ActiveRecord::Base
+        self.table_name = "articles"
+        validates_lengths_from_database :only => [:text_1]
+      end
+    end
+
+    context "with default locale" do
+      before do
+        I18n.backend.store_translations(:en, errors: { messages: { too_long_bytes: { one: "is too long (maximum is 1 byte)", other: "is too long (maximum is %{count} bytes)" } } })
+      end
+
+      after do
+        I18n.backend.reload!
+      end
+
+      it "should use the default i18n message for bytesize validation" do
+        skip "PostgreSQL doesn't support limits on text columns" if postgresql?
+        article = ArticleValidateI18n.new(:text_1 => "a" * 10)
+        article.valid?
+        article.errors["text_1"].join.should =~ /too long/
+        article.errors["text_1"].join.should =~ /bytes/
+      end
+    end
+
+    context "with custom locale override" do
+      before do
+        I18n.backend.store_translations(:en, errors: { messages: { too_long_bytes: { one: "ist zu lang (maximal 1 Byte)", other: "ist zu lang (maximal %{count} Bytes)" } } })
+      end
+
+      after do
+        I18n.backend.reload!
+      end
+
+      it "should use the overridden i18n message" do
+        skip "PostgreSQL doesn't support limits on text columns" if postgresql?
+        article = ArticleValidateI18n.new(:text_1 => "a" * 10)
+        article.valid?
+        article.errors["text_1"].join.should =~ /ist zu lang/
+        article.errors["text_1"].join.should =~ /Bytes/
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
## Summary

- Replace the hardcoded English string `"is too long (maximum is %{count} bytes)"` in `BytesizeValidator` with an i18n symbol `:too_long_bytes`
- Add a default English locale file (`config/locales/en.yml`) with the same message, loaded via the railtie
- This allows Rails applications to provide translations for the bytesize validation error message through their locale files

## Problem

The `validate_length_by_bytesize` method passes a hardcoded English string as the `:too_long` option to `BytesizeValidator`. Because ActiveModel's `LengthValidator` sets this string as `options[:message]`, it short-circuits Rails' entire i18n lookup chain in `Error.generate_message` (`activemodel/lib/active_model/error.rb:87`). This makes it impossible for applications to translate the "too long (bytes)" error message.

## Solution

Pass `:too_long_bytes` (a symbol) instead of the hardcoded string. When Rails sees a symbol as the `:message` option, `generate_message` at line 64 replaces `type` with that symbol and deletes `:message` from options. This allows the i18n lookup block (lines 84-87) to execute, checking:

1. `activerecord.errors.models.<model>.attributes.<attribute>.too_long_bytes`
2. `activerecord.errors.models.<model>.too_long_bytes`
3. `activerecord.errors.messages.too_long_bytes`
4. `errors.attributes.<attribute>.too_long_bytes`
5. `errors.messages.too_long_bytes`

The included `config/locales/en.yml` provides the English default at `errors.messages.too_long_bytes`, so **existing behavior is fully preserved** for apps that don't customize the message.

## Backward Compatibility

- The default English locale file ships with the gem and produces the exact same error message as before
- The railtie loads the locale file automatically for Rails apps
- Apps that were matching on the error string `/too long/` will continue to work
- Apps that want to translate can now override the key in their own locale files